### PR TITLE
Add submodule flavored do-localstack script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # LocalstackSetup
 Shared setup for localstack development
+
+## Usage Assumptions
+
+- This repository is intended to be added as a submodule under the `submodules/` directory of your main project.
+- Your main repository should have a `do.sh` script in its root. This script is expected to set variables such as `PROJECT_NAME`, `PROJECT_DIR`, and `TERRAFORM_DIR` before sourcing or invoking scripts from this submodule (see `do-localstack.sh` for details).
+- The scripts in this repo are designed to be sourced or called from your main repo's scripts, allowing you to manage Localstack containers and related infrastructure alongside your own services.
+- **Assumption:** The arrays `upFiles`, `downFiles`, `nukeFiles`, and `nukeSharedFiles` are initialized in your main script before sourcing `do-localstack.sh`. This allows the Localstack docker-compose file to be automatically added to these arrays.

--- a/do-localstack.sh
+++ b/do-localstack.sh
@@ -1,0 +1,37 @@
+LOCALSTACK_COMPOSE_FILE="submodules/LocalstackSetup/docker-compose.localstack.yml"
+
+if [ -f "$LOCALSTACK_COMPOSE_FILE" ]; then
+  if declare -p upFiles &>/dev/null; then
+    upFiles+=("$LOCALSTACK_COMPOSE_FILE")
+  fi
+  if declare -p downFiles &>/dev/null; then
+    downFiles+=("$LOCALSTACK_COMPOSE_FILE")
+  fi
+  if declare -p nukeFiles &>/dev/null; then
+    nukeFiles+=("$LOCALSTACK_COMPOSE_FILE")
+  fi
+  if declare -p nukeSharedFiles &>/dev/null; then
+    nukeSharedFiles+=("$LOCALSTACK_COMPOSE_FILE")
+  fi
+fi
+
+if [ "$1" = "deploy" ]; then
+  if [ -z "$PROJECT_NAME" ] || [ -z "$PROJECT_DIR" ] || [ -z "$TERRAFORM_DIR" ]; then
+    echo "PROJECT_NAME and PROJECT_DIR and TERRAFORM_DIR must be set before calling deploy."
+    exit 1
+  fi
+
+  OUTPUT_DIR="build/$PROJECT_NAME"
+  ORIG_DIR="$(pwd)"
+  echo "Building Lambda project..."
+  dotnet publish "$PROJECT_DIR" -c Release -o "$OUTPUT_DIR"
+
+  echo "Zipping Lambda..."
+  cd "$OUTPUT_DIR" || exit 1
+  zip -r lambda.zip .
+
+  echo "Deploying with Terraform..."
+  cd "$ORIG_DIR" || exit 1
+  cd "$TERRAFORM_DIR" || exit 1
+  terraform apply -auto-approve
+fi


### PR DESCRIPTION
Add a `do-localstack.sh` script which is intended to automatically weave into a top level `do.sh` script.

Also added deploy as a command to deploy configured project code to localstack using terraform.